### PR TITLE
Increase the number of Reddit pages and comments fetched in `GET` requests

### DIFF
--- a/public_sentiment_pipeline/README.md
+++ b/public_sentiment_pipeline/README.md
@@ -39,3 +39,7 @@ The following environment variables must be supplied in a .env file in order to 
 ## Archiving
 
 JSON files fetched from Reddit for each page are archived in an S3 bucket. They are named after the time they are created followed by the title.
+
+## Design decisions
+
+The pipeline processes 40 pages from a selected subreddit. The subreddit is chosen using the environment variable `REDDIT_TOPIC`. The number of pages to process is controlled from the global variable `MAX_REDDIT_PAGES` in `extract.py`. From each page 500 comments are processed. This value is set by the global variable `MAX_REDDIT_COMMENTS` in `extract.py`.

--- a/public_sentiment_pipeline/extract.py
+++ b/public_sentiment_pipeline/extract.py
@@ -50,7 +50,8 @@ def get_subreddit_json(config: dict, reddit_access_token: str) -> dict:
     auth_headers = {"Authorization": f"bearer {reddit_access_token}",
                     "User-Agent": "Media-Sentiment/0.1 by Media-Project"}
 
-    response = requests.get(f"{REDDIT_URL}{subreddit}", headers=auth_headers)
+    response = requests.get(f"{REDDIT_URL}{subreddit}/new",
+                            headers=auth_headers, params={"limit": 40})
     if response.status_code != 200:
         raise ConnectionError(
             f"Unexpected non-200 status code returned. Code: {response.status_code}")
@@ -111,7 +112,8 @@ def get_json_from_request(subreddit_url: str, reddit_access_token: str) -> dict:
     auth_headers = {"Authorization": f"bearer {reddit_access_token}",
                     "User-Agent": "Media-Sentiment/0.1 by Media-Project"}
 
-    response = requests.get(subreddit_url, headers=auth_headers)
+    response = requests.get(
+        subreddit_url, headers=auth_headers, params={"limit": 500, "show": "all"})
     if response.status_code != 200:
         raise ConnectionError(
             f"Unexpected non-200 status code returned for the url: {subreddit_url}. " +
@@ -166,6 +168,7 @@ def process_each_reddit_page(pages_list: list[dict], reddit_access_token: str, c
 
 def run_extract() -> list[dict]:  # pragma: no cover
     """Returns a list of dictionaries for each page in a subreddit."""
+    # configuration = os.environ
     configuration = dotenv_values()
     reddit_token = get_reddit_access_token(configuration)
     reddit_json = get_subreddit_json(configuration, reddit_token)

--- a/public_sentiment_pipeline/extract.py
+++ b/public_sentiment_pipeline/extract.py
@@ -9,6 +9,9 @@ from dotenv import dotenv_values
 from boto3 import client
 from pytz import timezone
 
+MAX_REDDIT_PAGES = 40
+MAX_REDDIT_COMMENTS = 500
+
 REDDIT_URL = "https://oauth.reddit.com/r/"
 SUBREDDIT_URL = "https://oauth.reddit.com/"
 REDDIT_ACCESS_TOKEN_URL = "https://www.reddit.com/api/v1/access_token"
@@ -49,9 +52,10 @@ def get_subreddit_json(config: dict, reddit_access_token: str) -> dict:
     print(f"Fetching data from the {subreddit} subreddit.")
     auth_headers = {"Authorization": f"bearer {reddit_access_token}",
                     "User-Agent": "Media-Sentiment/0.1 by Media-Project"}
+    parameters = {"limit": MAX_REDDIT_PAGES}
 
     response = requests.get(f"{REDDIT_URL}{subreddit}/new",
-                            headers=auth_headers, params={"limit": 40})
+                            headers=auth_headers, params=parameters)
     if response.status_code != 200:
         raise ConnectionError(
             f"Unexpected non-200 status code returned. Code: {response.status_code}")
@@ -111,9 +115,10 @@ def get_json_from_request(subreddit_url: str, reddit_access_token: str) -> dict:
     """Returns the contents of a subreddit page GET request."""
     auth_headers = {"Authorization": f"bearer {reddit_access_token}",
                     "User-Agent": "Media-Sentiment/0.1 by Media-Project"}
+    parameters = {"limit": MAX_REDDIT_COMMENTS, "show": "all"}
 
     response = requests.get(
-        subreddit_url, headers=auth_headers, params={"limit": 500, "show": "all"})
+        subreddit_url, headers=auth_headers, params=parameters)
     if response.status_code != 200:
         raise ConnectionError(
             f"Unexpected non-200 status code returned for the url: {subreddit_url}. " +

--- a/public_sentiment_pipeline/load.py
+++ b/public_sentiment_pipeline/load.py
@@ -124,6 +124,7 @@ def load_each_row_into_database(conn, page_response_list: list[dict]) -> None:
 
 
 if __name__ == "__main__":  # pragma: no cover
+    # configuration = os.environ
     configuration = dotenv_values()
     list_of_page_dict = run_transform()
     start = time.time()


### PR DESCRIPTION
- The number of pages and comments are now specified as additional parameters in the `GET` requests. They are controlled by the global variables `MAX_REDDIT_PAGES` and `MAX_REDDIT_COMMENTS`.
- `README.md` updated with details on the global variables.
- All unit tests passing.

**This should not be merged until #21 has been merged into `main` as this branch has not yet been tested on the AWS ECS task.**