### PR TITLE
Remove formatting from comments not recognised by Vader

### DIFF
--- a/public_sentiment_pipeline/README.md
+++ b/public_sentiment_pipeline/README.md
@@ -43,6 +43,8 @@ JSON files fetched from Reddit for each page are archived in an S3 bucket. They 
 
 The pipeline processes 40 pages from a selected subreddit. The subreddit is chosen using the environment variable `REDDIT_TOPIC`. The number of pages to process is controlled from the global variable `MAX_REDDIT_PAGES` in `extract.py`. From each page 500 comments are processed. This value is set by the global variable `MAX_REDDIT_COMMENTS` in `extract.py`.
 
+Formatting in comments that cannot be recognised by Vader is removed. `£`, `'`, `"` and `&` are kept in the comments. Other characters such as new lines or hyphens are removed. Markdown formatting such as web links are also removed, however, the text for the link is retained. Additionally, comments that do not contain the original intended text, such as `"**Removed/warning**"`, are removed entirely. This influences the parameter `included_comment_count`.
+
 ## Docker image
 
 Build a Docker image.

--- a/public_sentiment_pipeline/extract.py
+++ b/public_sentiment_pipeline/extract.py
@@ -139,9 +139,11 @@ def remove_unrecognised_formatting(comment: str) -> str:
     for text in characters_to_remove:
         comment = comment.replace(text, "")
 
-    comment = comment.replace("&amp;", "&")
-    comment = comment.replace("\\u2019", "'")
-    comment = comment.replace("\\u00a", "£")
+    characters_to_replace = (
+        {"&amp;": "&", "\\u2019": "'", "\\u00a": "£", "\\u201c": "\"", "\\u201d": "\""})
+
+    for text in characters_to_replace:
+        comment = comment.replace(text, characters_to_replace[text])
 
     comment = re.sub(r"\[(.+)\]\(.+\)", "\\1", comment)
 

--- a/public_sentiment_pipeline/extract.py
+++ b/public_sentiment_pipeline/extract.py
@@ -135,12 +135,13 @@ def read_json_as_text(json_filename: str) -> list[str]:  # pragma: no cover
 
 def remove_unrecognised_formatting(comment: str) -> str:
     """Removes formatting not recognised by Vader."""
-    characters_to_remove = ("\\n", "\\\n", "#x200B;", "\\u2013", "&gt;")
+    characters_to_remove = ("\n", "\\n", "#x200B;",
+                            "\\u2013", "&gt;", "\\u2026")
     for text in characters_to_remove:
         comment = comment.replace(text, "")
 
     characters_to_replace = (
-        {"&amp;": "&", "\\u2019": "'", "\\u00a": "£", "\\u201c": "\"", "\\u201d": "\""})
+        {"&amp;": "&", "\\u2018": "'", "\\u2019": "'", "\\u00a": "£", "\\u201c": "\"", "\\u201d": "\""})
 
     for text in characters_to_replace:
         comment = comment.replace(text, characters_to_replace[text])
@@ -154,10 +155,12 @@ def clean_reddit_comments(comment: str) -> str | bool:
     """Returns a comment in a format supported by Vader.
 
     If a comment is unsuitable to be used False is returned."""
+    comment = remove_unrecognised_formatting(comment)
     if (comment not in {"[removed]", "[deleted]"}
         and "**Removed/tempban**" not in comment
             and "**Removed/warning**" not in comment):
         return comment
+    return False
 
 
 def get_comments_list(json_filename: str) -> list[str]:
@@ -218,4 +221,4 @@ if __name__ == "__main__":  # pragma: no cover
 
     print(list_of_page_dict)
 
-    save_json_to_file(list_of_page_dict, "with_comments.json")
+    save_json_to_file(list_of_page_dict, "with_comments_2.json")

--- a/public_sentiment_pipeline/extract.py
+++ b/public_sentiment_pipeline/extract.py
@@ -135,7 +135,10 @@ def read_json_as_text(json_filename: str) -> list[str]:  # pragma: no cover
 
 def remove_unrecognised_formatting(comment: str) -> str:
     """Removes formatting not recognised by Vader."""
-    pass
+    characters_to_remove = ("\\n", "\\\n", "\\u2019")
+    for text in characters_to_remove:
+        comment = comment.replace(text, "")
+    return comment
 
 
 def clean_reddit_comments(comment: str) -> str | bool:

--- a/public_sentiment_pipeline/extract.py
+++ b/public_sentiment_pipeline/extract.py
@@ -135,7 +135,7 @@ def read_json_as_text(json_filename: str) -> list[str]:  # pragma: no cover
 
 def remove_unrecognised_formatting(comment: str) -> str:
     """Removes formatting not recognised by Vader."""
-    characters_to_remove = ("\\n", "\\\n", "\\u2019")
+    characters_to_remove = ("\\n", "\\\n", "\\u2019", "#x200B;")
     for text in characters_to_remove:
         comment = comment.replace(text, "")
 

--- a/public_sentiment_pipeline/extract.py
+++ b/public_sentiment_pipeline/extract.py
@@ -135,11 +135,15 @@ def read_json_as_text(json_filename: str) -> list[str]:  # pragma: no cover
 
 def remove_unrecognised_formatting(comment: str) -> str:
     """Removes formatting not recognised by Vader."""
-    characters_to_remove = ("\\n", "\\\n", "\\u2019", "#x200B;")
+    characters_to_remove = ("\\n", "\\\n", "#x200B;", "\\u2013", "&gt;")
     for text in characters_to_remove:
         comment = comment.replace(text, "")
 
     comment = comment.replace("&amp;", "&")
+    comment = comment.replace("\\u2019", "'")
+    comment = comment.replace("\\u00a", "£")
+
+    comment = re.sub(r"\[(.+)\]\(.+\)", "\\1", comment)
 
     return comment
 

--- a/public_sentiment_pipeline/extract.py
+++ b/public_sentiment_pipeline/extract.py
@@ -133,6 +133,21 @@ def read_json_as_text(json_filename: str) -> list[str]:  # pragma: no cover
         return f_obj.readlines()
 
 
+def remove_unrecognised_formatting(comment: str) -> str:
+    """Removes formatting not recognised by Vader."""
+    pass
+
+
+def clean_reddit_comments(comment: str) -> str | bool:
+    """Returns a comment in a format supported by Vader.
+
+    If a comment is unsuitable to be used False is returned."""
+    if (comment not in {"[removed]", "[deleted]"}
+        and "**Removed/tempban**" not in comment
+            and "**Removed/warning**" not in comment):
+        return comment
+
+
 def get_comments_list(json_filename: str) -> list[str]:
     """Returns a list of comments from a file."""
     comment_list = []
@@ -142,10 +157,9 @@ def get_comments_list(json_filename: str) -> list[str]:
         find_comment = re.search(r"\"body\": \"(.+)\",", line)
         if find_comment:
             comment = find_comment.group(1)
-            if (comment not in {"[removed]", "[deleted]"}
-                and "**Removed/tempban**" not in comment
-                    and "**Removed/warning**" not in comment):
-                comment_list.append(find_comment.group(1))
+            cleaned_comment = clean_reddit_comments(comment)
+            if cleaned_comment:
+                comment_list.append(cleaned_comment)
     return comment_list
 
 

--- a/public_sentiment_pipeline/extract.py
+++ b/public_sentiment_pipeline/extract.py
@@ -138,6 +138,9 @@ def remove_unrecognised_formatting(comment: str) -> str:
     characters_to_remove = ("\\n", "\\\n", "\\u2019")
     for text in characters_to_remove:
         comment = comment.replace(text, "")
+
+    comment = comment.replace("&amp;", "&")
+
     return comment
 
 

--- a/public_sentiment_pipeline/test_extract.py
+++ b/public_sentiment_pipeline/test_extract.py
@@ -242,13 +242,13 @@ def test_no_list_returned_if_exception_by_process_reddit_page(fake_comments_list
 
 
 @pytest.mark.parametrize("comment,cleaned_comment",
-                         [("\\n This contains single new lines \\n .", " This contains single new lines  ."),
-                          ("\\\n This contains double new lines \\\n .",
+                         [("\n This contains single new lines \n .", " This contains single new lines  ."),
+                          ("\\n This contains double new lines \\n .",
                            " This contains double new lines  ."),
                           ("&gt;comment&gt;", "comment"),
-                          ("\\\n&gt;", ""),
+                          ("\\n&gt;", ""),
                           ("wasn\\u2019t", "wasn't"),
-                          ("\\u2019,\\u2019", "','"),
+                          ("\\u2018,\\u2019", "','"),
                           ("&amp;", "&"),
                           ("h&amp;s", "h&s"),
                           ("#x200B;", ""),
@@ -258,7 +258,9 @@ def test_no_list_returned_if_exception_by_process_reddit_page(fake_comments_list
                            "They start just under £38k, most people can afford that. Citroen Ami  from £37,695"),
                           ("[Text](link)", "Text"),
                           ("\\u201cThis is a quote\\u201d", "\"This is a quote\""),
-                          ("\\u201c\\u201c\\u201d\\u201d", "\"\"\"\"")])
+                          ("\\u201c\\u201c\\u201d\\u201d", "\"\"\"\""),
+                          ("\\u2026", ""),
+                          ("\\u2026text\\u2026", "text")])
 def test_formatting_removed_from_comments(comment, cleaned_comment):
     """Tests formatting is removed from comments."""
     res = remove_unrecognised_formatting(comment)

--- a/public_sentiment_pipeline/test_extract.py
+++ b/public_sentiment_pipeline/test_extract.py
@@ -256,7 +256,9 @@ def test_no_list_returned_if_exception_by_process_reddit_page(fake_comments_list
                            "this is a comment"),
                           ("They start just under \\u00a38k, most people can afford that. \\n\\n[Citroen Ami \\u2013 from \\u00a37,695](https://parkers-images.bauersecure.com/pagefiles/308460/citroen_ami_001.jpg)",
                            "They start just under £38k, most people can afford that. Citroen Ami  from £37,695"),
-                          ("[Text](link)", "Text")])
+                          ("[Text](link)", "Text"),
+                          ("\\u201cThis is a quote\\u201d", "\"This is a quote\""),
+                          ("\\u201c\\u201c\\u201d\\u201d", "\"\"\"\"")])
 def test_formatting_removed_from_comments(comment, cleaned_comment):
     """Tests formatting is removed from comments."""
     res = remove_unrecognised_formatting(comment)

--- a/public_sentiment_pipeline/test_extract.py
+++ b/public_sentiment_pipeline/test_extract.py
@@ -247,15 +247,15 @@ def test_no_list_returned_if_exception_by_process_reddit_page(fake_comments_list
                            " This contains double new lines  ."),
                           ("&gt;comment&gt;", "comment"),
                           ("\\\n&gt;", ""),
-                          ("wasn\\u2019t", "wasnt"),
-                          ("\\u2019,\\u2019", ","),
+                          ("wasn\\u2019t", "wasn't"),
+                          ("\\u2019,\\u2019", "','"),
                           ("&amp;", "&"),
                           ("h&amp;s", "h&s"),
                           ("#x200B;", ""),
                           ("this#x200B; is#x200B; a#x200B; comment",
                            "this is a comment"),
                           ("They start just under \\u00a38k, most people can afford that. \\n\\n[Citroen Ami \\u2013 from \\u00a37,695](https://parkers-images.bauersecure.com/pagefiles/308460/citroen_ami_001.jpg)",
-                           "They start just under 38k, most people can afford that. Citroen Ami from 37,695"),
+                           "They start just under £38k, most people can afford that. Citroen Ami  from £37,695"),
                           ("[Text](link)", "Text")])
 def test_formatting_removed_from_comments(comment, cleaned_comment):
     """Tests formatting is removed from comments."""

--- a/public_sentiment_pipeline/test_extract.py
+++ b/public_sentiment_pipeline/test_extract.py
@@ -10,7 +10,7 @@ from re import match
 import pytest
 
 from reddit_conftest import FakeGet, FakePost, fake_subreddit_json, fake_subreddit_json_missing_entries, fake_json_content_1, fake_json_content_2
-from extract import get_subreddit_json, get_reddit_access_token, create_pages_list, create_json_filename, get_json_from_request, get_comments_list, process_each_reddit_page
+from extract import get_subreddit_json, get_reddit_access_token, create_pages_list, create_json_filename, get_json_from_request, get_comments_list, process_each_reddit_page, remove_unrecognised_formatting
 
 
 @patch("requests.get")
@@ -239,3 +239,26 @@ def test_no_list_returned_if_exception_by_process_reddit_page(fake_comments_list
 
     assert isinstance(res, list)
     assert res == []
+
+
+@pytest.mark.parametrize("comment,cleaned_comment",
+                         [("\\n This contains single new lines \\n .", " This contains single new lines  ."),
+                          ("\\\n This contains double new lines \\\n .",
+                           " This contains double new lines  ."),
+                          ("&gt;comment&gt;", "comment"),
+                          ("\\\n&gt;", ""),
+                          ("wasn\\u2019t", "wasnt"),
+                          ("\\u2019,\\u2019", ","),
+                          ("&amp;", "&"),
+                          ("h&amp;s", "h&s"),
+                          ("#x200B;", ""),
+                          ("this#x200B; is#x200B; a#x200B; comment",
+                           "this is a comment"),
+                          ("They start just under \\u00a38k, most people can afford that. \\n\\n[Citroen Ami \\u2013 from \\u00a37,695](https://parkers-images.bauersecure.com/pagefiles/308460/citroen_ami_001.jpg)",
+                           "They start just under 38k, most people can afford that. Citroen Ami from 37,695"),
+                          ("[Text](link)", "Text")])
+def test_formatting_removed_from_comments(comment, cleaned_comment):
+    """Tests formatting is removed from comments."""
+    res = remove_unrecognised_formatting(comment)
+
+    assert res == cleaned_comment


### PR DESCRIPTION
- TDD approach implemented to remove any unrecognised formatting and replace `£`/`&`/`'`/`"` unicode characters. Unit tests added and existing tests all passing.
- `README.md` updated with details on how the code has been implemented. This approach is not perfect. There are still sections of text that cannot be recognised by Vader such as emojis or web links.
- Pushed to ECR and running successfully as an ECS task.